### PR TITLE
Fix indefinite duration for not loaded vessels with recyclers

### DIFF
--- a/Snacks/GUI/SnackAppView.cs
+++ b/Snacks/GUI/SnackAppView.cs
@@ -138,36 +138,32 @@ namespace Snacks
                     GUILayout.Label("<color=yellow>The following are estimates</color>");
                 }
 
-                GUILayout.Label("<color=white><b>" + supplies.First().BodyName + ":</b></color>");
+                GUILayout.Label("<color=lightblue><b>" + supplies.First().BodyName + ":</b></color>");
                 foreach (ShipSupply supply in supplies)
                 {
                     if (supply.DayEstimate < 0)
                     {
-                        GUILayout.Label("<color=white>" + supply.VesselName + ": " + supply.SnackAmount + "/" + supply.SnackMaxAmount + "</color>");
-                        GUILayout.Label("<color=white>Crew: " + supply.CrewCount + "</color>");
-                        //GUILayout.Label("<color=white>Days: " + supply.DayEstimate + "</color>");
-                        GUILayout.Label("<color=white>Duration: Indefinite</color>");
+                        GUILayout.Label("<color=white><b>" + supply.VesselName + "</b></color>");
+                        GUILayout.Label("<color=white> Crew: " + supply.CrewCount + ", Snacks: " + supply.SnackAmount + "/" + supply.SnackMaxAmount + "</color>");
+                        GUILayout.Label("<color=white> Duration: Indefinite</color>");
                     }
                     else if (supply.Percent > 50)
                     {
-                        GUILayout.Label(supply.VesselName + ": " + supply.SnackAmount + "/" + supply.SnackMaxAmount);
-                        GUILayout.Label("Crew: " + supply.CrewCount);
-                        GUILayout.Label("Days: " + supply.DayEstimate);
-                        GUILayout.Label("Duration: " + timeFormat(supply.DayEstimate));
+                        GUILayout.Label("<color=white><b>" + supply.VesselName + "</b></color>");
+                        GUILayout.Label("<color=white> Crew: " + supply.CrewCount + ", Snacks: " + supply.SnackAmount + "/" + supply.SnackMaxAmount + "</color>");
+                        GUILayout.Label("<color=white> Duration: " + timeFormat(supply.DayEstimate) + "</color>");
                     }
                     else if (supply.Percent > 25)
                     {
-                        GUILayout.Label("<color=yellow>" + supply.VesselName + ": " + supply.SnackAmount + "/" + supply.SnackMaxAmount + "</color>");
-                        GUILayout.Label("<color=yellow>Crew: " + supply.CrewCount + "</color>");
-                        //GUILayout.Label("<color=yellow>Days: " + supply.DayEstimate + "</color>");
-                        GUILayout.Label("<color=yellow>Duration: " + timeFormat(supply.DayEstimate) + "</color>");
+                        GUILayout.Label("<color=yellow><b>" + supply.VesselName + "</b></color>");
+                        GUILayout.Label("<color=yellow> Crew: " + supply.CrewCount + ", Snacks: " + supply.SnackAmount + "/" + supply.SnackMaxAmount + "</color>");
+                        GUILayout.Label("<color=yellow> Duration: " + timeFormat(supply.DayEstimate) + "</color>");
                     }
                     else
                     {
-                        GUILayout.Label("<color=red>" + supply.VesselName + ": " + supply.SnackAmount + "/" + supply.SnackMaxAmount + "</color>");
-                        GUILayout.Label("<color=red>Crew: " + supply.CrewCount + "</color>");
-                        //GUILayout.Label("<color=red>Days: " + supply.DayEstimate + "</color>");
-                        GUILayout.Label("<color=red>Duration: " + timeFormat(supply.DayEstimate) + "</color>");
+                        GUILayout.Label("<color=red><b>" + supply.VesselName + "</b></color>");
+                        GUILayout.Label("<color=red> Crew: " + supply.CrewCount + ", Snacks: " + supply.SnackAmount + "/" + supply.SnackMaxAmount + "</color>");
+                        GUILayout.Label("<color=red> Duration: " + timeFormat(supply.DayEstimate) + "</color>");
                     }
                 }
             }

--- a/Snacks/LifeSupport/SnackSnapshot.cs
+++ b/Snacks/LifeSupport/SnackSnapshot.cs
@@ -247,13 +247,16 @@ namespace Snacks
                                     }
                                 }
                             }
-
-                            //Account for recyclers
-                            if (crewCount >= recycleCapacity)
-                                snackConsumption -= snackProduction;
-                            else
-                                snackConsumption -= snackProduction * (crewCount / recycleCapacity);
                         }
+                    }
+
+                   if (SnacksProperties.RecyclersEnabled)
+                    {
+                        //Account for recyclers
+                        if (crewCount >= recycleCapacity)
+                            snackConsumption -= snackProduction;
+                        else
+                            snackConsumption -= snackProduction * (crewCount / recycleCapacity);
                     }
 
                     //Debug.Log(pv.vesselName + "1");


### PR DESCRIPTION
Calculation of snackConsumption is wrong in case of not loaded vessels with recyclers. The reduction code runs multiple times for every protopart, so snackConsumption value becomes negative, and so SnackSupply window always shows indefinite duration for not loaded vessels with recyclers.