### PR TITLE
Adjustment of time definitions to account for non-standard system scales.

### DIFF
--- a/Snacks/GUI/SnackAppView.cs
+++ b/Snacks/GUI/SnackAppView.cs
@@ -40,10 +40,11 @@ namespace Snacks
         {
             get
             {
-                if (GameSettings.KERBIN_TIME)
-                    return 426.08f;
-                else
-                    return 365f;
+                //if (GameSettings.KERBIN_TIME)
+                //    return 426.08f;
+                //else
+                //    return 365f;
+                return (KSPUtil.dateTimeFormatter.Year / KSPUtil.dateTimeFormatter.Day);
             }
         }
 
@@ -62,10 +63,11 @@ namespace Snacks
         {
             get
             {
-                if (GameSettings.KERBIN_TIME)
-                    return 6f;
-                else
-                    return 24f;
+                //if (GameSettings.KERBIN_TIME)
+                //    return 6f;
+                //else
+                //    return 24f;
+                return (KSPUtil.dateTimeFormatter.Day / 3600);
             }
         }
 

--- a/Snacks/GUI/SnackAppView.cs
+++ b/Snacks/GUI/SnackAppView.cs
@@ -67,7 +67,7 @@ namespace Snacks
                 //    return 6f;
                 //else
                 //    return 24f;
-                return (KSPUtil.dateTimeFormatter.Day / 3600);
+                return (KSPUtil.dateTimeFormatter.Day / KSPUtil.dateTimeFormatter.Hour);
             }
         }
 

--- a/Snacks/LifeSupport/SnackController.cs
+++ b/Snacks/LifeSupport/SnackController.cs
@@ -417,10 +417,11 @@ namespace Snacks
         {
 //            snackFrequency = 5;
             //Seconds per day = 6 * 60 * 60 = 21600
-            if (GameSettings.KERBIN_TIME)
-                snackFrequency = (6 * 3600) / SnacksProperties.MealsPerDay;
-            else
-                snackFrequency = (24 * 3600) / SnacksProperties.MealsPerDay;
+            //if (GameSettings.KERBIN_TIME)
+            //    snackFrequency = (6 * 3600) / SnacksProperties.MealsPerDay;
+            //else
+            //    snackFrequency = (24 * 3600) / SnacksProperties.MealsPerDay;
+            snackFrequency = ((KSPUtil.dateTimeFormatter.Day) / SnacksProperties.MealsPerDay);
 
             //Make sure that the penalties know about the update
             foreach (ISnacksPenalty handler in penaltyHandlers)

--- a/Snacks/Settings/SnacksProperties.cs
+++ b/Snacks/Settings/SnacksProperties.cs
@@ -239,10 +239,11 @@ namespace Snacks
                         return 120;
 
                     case FaintTime.OneDay:
-                        if (GameSettings.KERBIN_TIME)
-                            return 360;
-                        else
-                            return 1440;
+                        //if (GameSettings.KERBIN_TIME)
+                        //    return 360;
+                        //else
+                        //    return 1440;
+                        return KSPUtil.dateTimeFormatter.Day;
                 }
             }
         }

--- a/Snacks/Utilities/WindowUtils.cs
+++ b/Snacks/Utilities/WindowUtils.cs
@@ -38,7 +38,7 @@ namespace Snacks
     {
         const double SECONDS_PER_MINUTE = 60.0;
         const double MINUTES_PER_HOUR = 60.0;
-        static double HOURS_PER_DAY = (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
+        static double HOURS_PER_DAY = KSPUtil.dateTimeFormatter.Day / 3600; // (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
         public static double SECONDS_PER_DAY = SECONDS_PER_MINUTE*MINUTES_PER_HOUR*HOURS_PER_DAY;
 
         public static double ToDegrees(double radians)

--- a/Snacks/Utilities/WindowUtils.cs
+++ b/Snacks/Utilities/WindowUtils.cs
@@ -50,7 +50,13 @@ namespace Snacks
                 return KSPUtil.dateTimeFormatter.Hour / KSPUtil.dateTimeFormatter.Minute;
             }
         }
-        static double HOURS_PER_DAY = KSPUtil.dateTimeFormatter.Day / 3600; // (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
+        static double HOURS_PER_DAY
+        {
+            get
+            {
+                return KSPUtil.dateTimeFormatter.Day / KSPUtil.dateTimeFormatter.Hour; // (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
+            }
+        }
         public static double SECONDS_PER_DAY = SECONDS_PER_MINUTE*MINUTES_PER_HOUR*HOURS_PER_DAY;
 
         public static double ToDegrees(double radians)

--- a/Snacks/Utilities/WindowUtils.cs
+++ b/Snacks/Utilities/WindowUtils.cs
@@ -43,7 +43,13 @@ namespace Snacks
                 return KSPUtil.dateTimeFormatter.Minute;
             }
         }
-        const double MINUTES_PER_HOUR = 60.0;
+        double MINUTES_PER_HOUR
+        {
+            get
+            {
+                return KSPUtil.dateTimeFormatter.Hour / KSPUtil.dateTimeFormatter.Minute;
+            }
+        }
         static double HOURS_PER_DAY = KSPUtil.dateTimeFormatter.Day / 3600; // (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
         public static double SECONDS_PER_DAY = SECONDS_PER_MINUTE*MINUTES_PER_HOUR*HOURS_PER_DAY;
 

--- a/Snacks/Utilities/WindowUtils.cs
+++ b/Snacks/Utilities/WindowUtils.cs
@@ -36,7 +36,13 @@ namespace Snacks
 {
     public static class WindowUtils
     {
-        const double SECONDS_PER_MINUTE = 60.0;
+        double SECONDS_PER_MINUTE 
+        {
+            get
+            {
+                return KSPUtil.dateTimeFormatter.Minute;
+            }
+        }
         const double MINUTES_PER_HOUR = 60.0;
         static double HOURS_PER_DAY = KSPUtil.dateTimeFormatter.Day / 3600; // (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
         public static double SECONDS_PER_DAY = SECONDS_PER_MINUTE*MINUTES_PER_HOUR*HOURS_PER_DAY;

--- a/Snacks/Utilities/WindowUtils.cs
+++ b/Snacks/Utilities/WindowUtils.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * WindowUtils.cs
  * 
  * Thunder Aerospace Corporation's library for the Kerbal Space Program, by Taranis Elsu
@@ -36,28 +36,13 @@ namespace Snacks
 {
     public static class WindowUtils
     {
-        double SECONDS_PER_MINUTE 
-        {
-            get
-            {
-                return KSPUtil.dateTimeFormatter.Minute;
-            }
-        }
-        double MINUTES_PER_HOUR
-        {
-            get
-            {
-                return KSPUtil.dateTimeFormatter.Hour / KSPUtil.dateTimeFormatter.Minute;
-            }
-        }
-        static double HOURS_PER_DAY
-        {
-            get
-            {
-                return KSPUtil.dateTimeFormatter.Day / KSPUtil.dateTimeFormatter.Hour; // (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
-            }
-        }
-        public static double SECONDS_PER_DAY = SECONDS_PER_MINUTE*MINUTES_PER_HOUR*HOURS_PER_DAY;
+        public static double SECONDS_PER_MINUTE => KSPUtil.dateTimeFormatter.Minute;
+
+        public static double MINUTES_PER_HOUR => KSPUtil.dateTimeFormatter.Hour / KSPUtil.dateTimeFormatter.Minute;
+
+        public static double HOURS_PER_DAY => KSPUtil.dateTimeFormatter.Day / KSPUtil.dateTimeFormatter.Hour; // (GameSettings.KERBIN_TIME) ? 6.0 : 24.0;
+
+        public static double SECONDS_PER_DAY = KSPUtil.dateTimeFormatter.Day; // SECONDS_PER_MINUTE*MINUTES_PER_HOUR*HOURS_PER_DAY;
 
         public static double ToDegrees(double radians)
         {


### PR DESCRIPTION
Hi. When using either a non-stock system or a rescaled system, it is common to use the Kronometer mod in conjunction with Kopernicus. The rescaled systems typically result in a day/year length that differs from either the 24/365 or 6/426.08 scales.

This patch changes the encoded references for a day/year length from being hard coded to being picked up from the KSPUtil.dateTimeFormatter method. This returns either of the standard lengths in a stock game, and this method is overloaded by Kronometer to return the correct values for a rescaled system. Credit due to @Aelfhe1m and @TriggerAu for similar patches to KerbalAlarmClock and TransferWindowPlanner for leading me in the right direction.

The expected results are that both SnacksPerDay and the estimated remaining snacks display reflect the actual length of the day in the system being used.

I have tested the changes on my system and it appears to be working, but I am not very proficient in C#/Unity and would like your opinion on the changes. Thanks much, I really enjoy using your mods!