### PR TITLE
Rational Resources support

### DIFF
--- a/GameData/WildBlueIndustries/Snacks/ModuleManagerPatches/Snacks_RationalResources.cfg
+++ b/GameData/WildBlueIndustries/Snacks/ModuleManagerPatches/Snacks_RationalResources.cfg
@@ -1,10 +1,21 @@
-@PART[*]:HAS[@MODULE[SnackProcessor]]:NEEDS[RationalResources]:AFTER[Snacks]
+@PART[*]:HAS[@MODULE[SnackProcessor]]:NEEDS[RationalResources,CommunityResourcePack,!ClassicStock]:AFTER[Snacks]
 {
   @MODULE[SnackProcessor]
   {
     @INPUT_RESOURCE:HAS[#ResourceName[Ore]]
     {
       @ResourceName = Hydrates
+    }
+  }
+}
+
+@PART[*]:HAS[@MODULE[SnackProcessor]]:NEEDS[RationalResources,ClassicStock]:AFTER[Snacks]
+{
+  @MODULE[SnackProcessor]
+  {
+    @INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+    {
+      @ResourceName = Rock
     }
   }
 }

--- a/GameData/WildBlueIndustries/Snacks/ModuleManagerPatches/Snacks_RationalResources.cfg
+++ b/GameData/WildBlueIndustries/Snacks/ModuleManagerPatches/Snacks_RationalResources.cfg
@@ -1,0 +1,10 @@
+@PART[*]:HAS[@MODULE[SnackProcessor]]:NEEDS[RationalResources]:AFTER[Snacks]
+{
+  @MODULE[SnackProcessor]
+  {
+    @INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+    {
+      @ResourceName = Hydrates
+    }
+  }
+}


### PR DESCRIPTION
Create Snacks from Hydrates instead of Ore if Rational Resources is installed. Hydrates are described as ubiquitous in RR, and they contain at least some elements of CHON, making them a good candidate for a simple drop-in replacement for nerfed Ore.