### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/Snacks/Snacks.version
+++ b/GameData/WildBlueIndustries/Snacks/Snacks.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Snacks",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Snacks/master/GameData/Snacks/Snacks.version",
+    "URL":"https://github.com/Angel-125/Snacks/raw/master/GameData/WildBlueIndustries/Snacks/Snacks.version",
     "DOWNLOAD":"https://github.com/Angel-125/Snacks/releases",
     "GITHUB":
     {


### PR DESCRIPTION
The current version file's URL property is a 404.
Now it's fixed.

Tagging @Angel-125 because not everyone has GitHub notifications enabled for pull requests.

https://github.com/DasSkelett/AVC-VersionFileValidator is a tool by @DasSkelett that helps a lot with things like this.