### PR TITLE
Fix high CPU usage in simulators

### DIFF
--- a/Snacks/Simulator/SnackSimThread.cs
+++ b/Snacks/Simulator/SnackSimThread.cs
@@ -128,6 +128,7 @@ namespace Snacks
                 if (!canRun)
                 {
                     mutex.ReleaseMutex();
+                    Thread.Sleep(100);
                     return;
                 }
 
@@ -176,6 +177,10 @@ namespace Snacks
                         }
                         mutex.ReleaseMutex();
                     }
+                }
+                else
+                {
+                    Thread.Sleep(100);
                 }
 
             }


### PR DESCRIPTION
Hi @Angel-125, first of all thank you for this awesome mod. I had some issues with the simulator (running KSP v1.10.1 on macOS Catalina). Actually with some sleep commands while simulator is not null in the thread routine seems to overcome the high CPU usage. I'm leaving the PR here in case you're interested.

I think a "better" solution would be to add some Wait mutexes, since the `Mutex.WaitOne()` used here is not really doing his job. Probably my understanding is limited, but I think this could be a good start.

Furthermore, reducing the sleeping period to ~20ms should be enough.