### PR TITLE
Make small snacks containers manipulable for construction/inventory

### DIFF
--- a/GameData/WildBlueIndustries/Snacks/Parts/Payload/radialSnackTin.cfg
+++ b/GameData/WildBlueIndustries/Snacks/Parts/Payload/radialSnackTin.cfg
@@ -79,4 +79,10 @@ PART
 		}
 	}
 
+	MODULE
+	{
+		name = ModuleCargoPart
+		stackableQuantity = 1
+		packedVolume = 50
+	}	
 }

--- a/GameData/WildBlueIndustries/Snacks/Parts/Payload/snackTin500.cfg
+++ b/GameData/WildBlueIndustries/Snacks/Parts/Payload/snackTin500.cfg
@@ -83,4 +83,10 @@ PART
 
 		}
 	}
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 920
+	}	
 }


### PR DESCRIPTION
Radial snack container becomes backable in inventory. The smallest inline tin can't be packed in inventory, but can be manipulated in orbital construction. 